### PR TITLE
Navbar link fix

### DIFF
--- a/navbar.inc
+++ b/navbar.inc
@@ -10,22 +10,22 @@
   </div>
   <ul>
     <li>
-      <a class="nav-item" href="/gotogro-msp-20-v2/addOrder.php">
+      <a class="nav-item" href="/addOrder.php">
         <?php echo file_get_contents("./assets/icons/FaCashRegister.svg"); ?> Add Order
       </a>
     </li>
     <li>
-      <a class="nav-item" href="/gotogro-msp-20-v2/addMember.php">
+      <a class="nav-item" href="/addMember.php">
         <?php echo file_get_contents("./assets/icons/MdPersonAddAlt1.svg"); ?> Add Member
       </a>
     </li>
     <li>
-      <a class="nav-item" href="/gotogro-msp-20-v2/memberInfo.php">
+      <a class="nav-item" href="/memberInfo.php">
         <?php echo file_get_contents("./assets/icons/MdPersonSearch.svg"); ?> Member Info
       </a>
     </li>
     <li>
-      <a class="nav-item" href="/gotogro-msp-20-v2/salesReport.php">
+      <a class="nav-item" href="/salesReport.php">
         <?php echo file_get_contents("./assets/icons/RiFileList3Fill.svg"); ?> Sales Report
       </a>
     </li>


### PR DESCRIPTION
Changes summary
- The reason the navbar was broken was because of the way XAMPP was set up locally, not the way the navbar was coded. So I've reverted the links so they don't have the duplicated `/gotogro-msp-20-v2` when visiting the site on PROD
- The url would've been `https://gotogro-msp-20.herokuapp.com/gotogro-msp-20-v2/addMember.php`

This will fix the local XAMPP issue. We wanna change the root to point to our project folder instead of `/htdocs`
https://prismict.com/change-xampp-htdocs-directory-osx/